### PR TITLE
Fixed Ubuntu 20.04 CI build for torch

### DIFF
--- a/.github/workflows/tests_quick.yml
+++ b/.github/workflows/tests_quick.yml
@@ -60,7 +60,7 @@ jobs:
 
   test-torch:
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Forgot to change to 20.04 for `test-torch` CI job.

Related to https://github.com/ajinkya-kulkarni/torchstain/pull/1. CIs should run correct now.